### PR TITLE
variables types cleaning

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,12 @@
       "PLATFORMIO_CALLER": "vscode"
    },
    "files.associations": {
-      "functional": "cpp"
+      "functional": "cpp",
+      "*.tcc": "cpp",
+      "fstream": "cpp",
+      "istream": "cpp",
+      "ostream": "cpp",
+      "sstream": "cpp"
    },
    "C_Cpp.dimInactiveRegions": true
 }

--- a/include/Structs.h
+++ b/include/Structs.h
@@ -3,8 +3,8 @@
 
 struct stDogTimeData
 {
-   unsigned long Time;
-   long CrossingTime;
+   long long Time;
+   long long CrossingTime;
 };
 
 struct stDogData
@@ -19,17 +19,17 @@ struct stDogData
 struct stRaceData
 {
    uint Id;
-   unsigned long StartTime;
-   unsigned long EndTime;
-   unsigned long ElapsedTime;
+   long long StartTime;
+   long long EndTime;
+   long long ElapsedTime;
    uint8_t RaceState;
    stDogData DogData[4];
-   long TotalCrossingTime;
+   long long TotalCrossingTime;
 };
 
 struct stSystemData
 {
-   unsigned long Uptime;
+   long long Uptime;
    uint32_t FreeHeap;
    RESET_REASON CPU0ResetReason;
    RESET_REASON CPU1ResetReason;
@@ -46,6 +46,6 @@ struct stLightsState
 struct stInputSignal
 {
    uint8_t Pin;
-   unsigned long LastTriggerTime;
+   long long LastTriggerTime;
    word CoolDownTime;
 };

--- a/include/config.h
+++ b/include/config.h
@@ -22,8 +22,8 @@
 #ifndef GLOBALVAR_H
 #define GLOBALVAR_H
 
-#define Simulate false                    // Set to true to enable race simulation (see Simulator.h/.cpp)
-#define JTAG false                        // when set to true you need converter board with pins remappig and jtag + programing port. It deactite featuers: LSR BTN+LED, battery sensor, switch button
+#define Simulate true                     // Set to true to enable race simulation (see Simulator.h/.cpp)
+#define JTAG true                         // when set to true you need converter board with pins remappig and jtag + programing port. It deactite featuers: LSR BTN+LED, battery sensor, switch button
 #define NumSimulatedRaces     3           // number of prepeared simulated races. Sererial interface command to chane interface: e.g. RACE 1
 #define RecoveryResetTimer    0           // Timer in minutes counted since ESP32 hard/software reset. After timer expire Triggering reset via remote or UART will trigger full ESP32 SW reset and not only race data reset
 

--- a/include/config.h
+++ b/include/config.h
@@ -25,7 +25,7 @@
 #define Simulate true                     // Set to true to enable race simulation (see Simulator.h/.cpp)
 #define JTAG true                         // when set to true you need converter board with pins remappig and jtag + programing port. It deactite featuers: LSR BTN+LED, battery sensor, switch button
 #define NumSimulatedRaces     3           // number of prepeared simulated races. Sererial interface command to chane interface: e.g. RACE 1
-#define RecoveryResetTimer    30          // Timer in minutes counted since ESP32 hard/software reset. After timer expire Triggering reset via remote or UART will trigger full ESP32 SW reset and not only race data reset
+#define RecoveryResetTimer    0           // Timer in minutes counted since ESP32 hard/software reset. After timer expire Triggering reset via remote or UART will trigger full ESP32 SW reset and not only race data reset
 
 #define LIGHTSCHAINS          2           // Numer of WS281x lights chains. 1 - one chain of 5 pixels/lights, 2 - two chains --> 10 pixels/lights, etc.
 

--- a/lib/LCDController/LCDController.h
+++ b/lib/LCDController/LCDController.h
@@ -56,8 +56,8 @@ private:
    void _UpdateLCD(int iLine, int iPosition, String strText, int iFieldLength);
    LiquidCrystal *_Clcd1;
    LiquidCrystal *_Clcd2;
-   unsigned long _lLastLCDUpdate = 0;
-   unsigned int _iLCDUpdateInterval = 500; //500ms update interval
+   long long _lLastLCDUpdate = 0;
+   long long _iLCDUpdateInterval = 500; //500ms update interval
 
    struct SLCDField
    {

--- a/lib/LightsController/LightsController.h
+++ b/lib/LightsController/LightsController.h
@@ -90,22 +90,22 @@ private:
 
    bool _bStartSequenceStarted = 0;
 
-   unsigned long _lLightsOnSchedule[6];
-   unsigned long _lLightsOutSchedule[6];
+   long long _lLightsOnSchedule[6];
+   long long _lLightsOutSchedule[6];
 
    Lights _byLightsArray[6] = {
-       WHITE,
-       RED,
-       YELLOW1,
-       BLUE,
-       YELLOW2,
-       GREEN};
+      WHITE,
+      RED,
+      YELLOW1,
+      BLUE,
+      YELLOW2,
+      GREEN};
 
    Lights _byDogErrorLigths[4] = {
-       RED,
-       BLUE,
-       YELLOW2,
-       GREEN};
+      RED,
+      BLUE,
+      YELLOW2,
+      GREEN};
 
 #ifdef WS281x
    struct SNeoPixelConfig

--- a/lib/RaceHandler/RaceHandler.h
+++ b/lib/RaceHandler/RaceHandler.h
@@ -36,7 +36,7 @@ class RaceHandlerClass
    void StartTimers();
    void StartRace();
    void StopRace();
-   void StopRace(unsigned long lStopTime);
+   void StopRace(long long lStopTime);
    void ResetRace();
    void TriggerSensor1();
    void TriggerSensor2();
@@ -50,11 +50,11 @@ class RaceHandlerClass
 
    double GetRaceTime();
    double GetDogTime(uint8_t iDogNumber, int8_t iRunNumber = -1);
-   unsigned long GetDogTimeMillis(uint8_t iDogNumber, int8_t iRunNumber = -1);
+   long long GetDogTimeMillis(uint8_t iDogNumber, int8_t iRunNumber = -1);
    String GetCrossingTime(uint8_t iDogNumber, int8_t iRunNumber = -1);
-   unsigned long GetCrossingTimeMillis(uint8_t iDogNumber, int8_t iRunNumber = -1);
+   long long GetCrossingTimeMillis(uint8_t iDogNumber, int8_t iRunNumber = -1);
    String GetRerunInfo(uint8_t iDogNumber);
-   long GetTotalCrossingTimeMillis();
+   long long GetTotalCrossingTimeMillis();
    double GetNetTime();
 
    String GetRaceStateString();
@@ -65,12 +65,12 @@ class RaceHandlerClass
    boolean GetRunDirection();
 
 private:
-   unsigned long _lRaceStartTime;
-   unsigned long _lRaceEndTime;
-   unsigned long _lRaceTime;
-   unsigned long _lPerfectCrossingTime;
-   unsigned long _lLastTransitionStringUpdate;
-   unsigned long _lFalseStartTime = 0;
+   long long _lRaceStartTime;
+   long long _lRaceEndTime;
+   long long _lRaceTime;
+   long long _lPerfectCrossingTime;
+   long long _lLastTransitionStringUpdate;
+   long long _lFalseStartTime = 0;
 
    uint8_t  _iS1Pin;
    uint8_t  _iS2Pin;
@@ -78,8 +78,8 @@ private:
 
    struct STriggerRecord
    {
-      volatile uint8_t iSensorNumber;
-      volatile unsigned long lTriggerTime;
+      volatile int iSensorNumber;
+      volatile long long lTriggerTime;
       volatile int iSensorState;
    };
 #define TRIGGER_QUEUE_LENGTH 50
@@ -92,13 +92,13 @@ private:
    bool _bDogFaults[4];
    bool _bRerunBusy;
    uint8_t _iDogRunCounters[4];  //Number of (re-)runs for each dog
-   unsigned long _lLastDogTimeReturnTimeStamp[4];
+   long long _lLastDogTimeReturnTimeStamp[4];
    uint8_t _iLastReturnedRunNumber[4];
-   unsigned long _lDogEnterTimes[4];
-   unsigned long _lDogExitTimes[4];
+   long long _lDogEnterTimes[4];
+   long long _lDogExitTimes[4];
 
-   unsigned long _lDogTimes[4][4];
-   long _lCrossingTimes[4][4];
+   long long _lDogTimes[4][4];
+   long long _lCrossingTimes[4][4];
 
    String _strTransition;
    
@@ -107,7 +107,7 @@ private:
       COMINGBACK
    };
    _byDogStates _byDogState;
-   bool _bGatesClear = false;
+   bool _bGatesClear = true;
 
    stRaceData _HistoricRaceData[NUM_HISTORIC_RACE_RECORDS];
    uint _iCurrentRaceId;

--- a/lib/Simulator/Simulator.cpp
+++ b/lib/Simulator/Simulator.cpp
@@ -253,7 +253,7 @@ void SimulatorClass::Main()
    }
 }
 
-void SimulatorClass::ChangeSimulatedRaceID(uint8_t iSimulatedRaceID)
+void SimulatorClass::ChangeSimulatedRaceID(uint iSimulatedRaceID)
 {
    if (RaceHandler.RaceState == RaceHandler.STOPPED)
    {

--- a/lib/Simulator/Simulator.cpp
+++ b/lib/Simulator/Simulator.cpp
@@ -236,7 +236,7 @@ void SimulatorClass::Main()
       //Pending record doesn't contain valid data, this means we've reched the end of our queue
       return;
    }
-   long lRaceElapsedTime = GET_MICROS - RaceHandler._lRaceStartTime;
+   long long lRaceElapsedTime = GET_MICROS - RaceHandler._lRaceStartTime;
    //Simulate sensors
    if (RaceHandler.RaceState != RaceHandler.STOPPED && PendingRecord.lTriggerTime <= (long)lRaceElapsedTime)
    {
@@ -253,7 +253,7 @@ void SimulatorClass::Main()
    }
 }
 
-void SimulatorClass::ChangeSimulatedRaceID(unsigned long iSimulatedRaceID)
+void SimulatorClass::ChangeSimulatedRaceID(uint8_t iSimulatedRaceID)
 {
    if (RaceHandler.RaceState == RaceHandler.STOPPED)
    {

--- a/lib/Simulator/Simulator.h
+++ b/lib/Simulator/Simulator.h
@@ -20,7 +20,7 @@ protected:
 
 public:
    void init(uint8_t iS1Pin, uint8_t iS2Pin);
-   void ChangeSimulatedRaceID(unsigned long iSimulatedRaceID);
+   void ChangeSimulatedRaceID(uint8_t iSimulatedRaceID);
    void Main();
 
 

--- a/lib/Simulator/Simulator.h
+++ b/lib/Simulator/Simulator.h
@@ -20,7 +20,7 @@ protected:
 
 public:
    void init(uint8_t iS1Pin, uint8_t iS2Pin);
-   void ChangeSimulatedRaceID(uint8_t iSimulatedRaceID);
+   void ChangeSimulatedRaceID(uint iSimulatedRaceID);
    void Main();
 
 

--- a/lib/WebHandler/WebHandler.cpp
+++ b/lib/WebHandler/WebHandler.cpp
@@ -244,7 +244,7 @@ void WebHandlerClass::loop()
          _lLastRaceDataBroadcast = GET_MICROS / 1000;
       }
    }
-   if (GET_MICROS / 1000- _lLastSystemDataBroadcast > _lSystemDataBroadcastInterval)
+   if (GET_MICROS / 1000 - _lLastSystemDataBroadcast > _lSystemDataBroadcastInterval)
    {
       _GetSystemData();
       _SendSystemData();
@@ -545,7 +545,7 @@ void WebHandlerClass::_onAuth(AsyncWebServerRequest *request)
    if (!_authenticate(request))
       return request->requestAuthentication("", false);
    IPAddress ip = request->client()->remoteIP();
-   unsigned long now = GET_MICROS / 1000;
+   long long now = GET_MICROS / 1000;
    unsigned short index;
    for (index = 0; index < WS_TICKET_BUFFER_SIZE; index++)
    {
@@ -585,7 +585,7 @@ bool WebHandlerClass::_wsAuth(AsyncWebSocketClient *client)
 {
 
    IPAddress ip = client->remoteIP();
-   unsigned long now = GET_MICROS / 1000;
+   long long now = GET_MICROS / 1000;
    unsigned short index = 0;
 
    //TODO: Here be dragons, this way of 'authenticating' is all but secure

--- a/lib/WebHandler/WebHandler.h
+++ b/lib/WebHandler/WebHandler.h
@@ -45,17 +45,17 @@ protected:
 
    void _onHome(AsyncWebServerRequest *request);
 
-   unsigned long _lLastRaceDataBroadcast;
-   unsigned long _lRaceDataBroadcastInterval;
-   unsigned long _lLastSystemDataBroadcast;
-   unsigned long _lSystemDataBroadcastInterval;
+   long long _lLastRaceDataBroadcast;
+   long long _lRaceDataBroadcastInterval;
+   long long _lLastSystemDataBroadcast;
+   long long _lSystemDataBroadcastInterval;
    stSystemData _SystemData;
    char _last_modified[50];
 
    typedef struct
    {
       IPAddress ip;
-      unsigned long timestamp = 0;
+      long long timestamp = 0;
    } ws_ticket_t;
    ws_ticket_t _ticket[WS_TICKET_BUFFER_SIZE];
 

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -109,8 +109,8 @@ char cDogTime[8];
 char cDogCrossingTime[8];
 char cElapsedRaceTime[8];
 char cTeamNetTime[8];
-long lHeapPreviousMillis = 0;
-long lHeapInterval = 10000;
+long long lHeapPreviousMillis = 0;
+long long lHeapInterval = 10000;
 
 //Initialise Lights stuff
 #ifdef WS281x
@@ -137,7 +137,7 @@ stInputSignal SideSwitch = {iSideSwitchPin, 0, 500};
 #endif
 
 //Set last serial output variable
-long lLastSerialOutput = 0;
+long long lLastSerialOutput = 0;
 
 //remote control pins
 int iRC0Pin = 19;
@@ -148,7 +148,7 @@ int iRC4Pin = 16;
 int iRC5Pin = 4;
 
 //Array to hold last time button presses
-unsigned long lLastRCPress[6] = {0, 0, 0, 0, 0, 0};
+long long lLastRCPress[6] = {0, 0, 0, 0, 0, 0};
 
 #if !JTAG
 uint8_t iLCDData4Pin = 13;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -169,7 +169,7 @@ LiquidCrystal lcd2(iLCDRSPin, iLCDE2Pin, iLCDData4Pin, iLCDData5Pin, iLCDData6Pi
 
 //String for serial comms storage
 String strSerialData;
-unsigned long iSimulatedRaceID = 0;
+uint iSimulatedRaceID = 0;
 byte bySerialIndex = 0;
 boolean bSerialStringComplete = false;
 
@@ -370,6 +370,7 @@ void loop()
       ResetRace();
    }
 
+#if Simulate
    //Change Race ID (only serial command), e.g. RACE 1 or RACE 2
    if (bSerialStringComplete && strSerialData.startsWith("RACE"))
    {
@@ -381,6 +382,7 @@ void loop()
       }
       Simulator.ChangeSimulatedRaceID(iSimulatedRaceID);
    }
+#endif
 
    //Dog0 fault RC button
    if ((digitalRead(iRC2Pin) == HIGH && (GET_MICROS / 1000 - lLastRCPress[2] > 2000)) || (bSerialStringComplete && strSerialData == "D0F"))


### PR DESCRIPTION
using "unsign long" for time represented in microseconds could be a reason for instability after ~75min. All timing related parameters changed to "long long". Few other cleanings to address all VSCode conversion warnings.